### PR TITLE
Add sticky navigation and modernize post listings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,13 @@
     <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
   </head>
   <body class="bg-gray-900 text-gray-100">
-    <main class="container mx-auto px-4 py-8">
+    <nav class="fixed top-0 left-0 w-full bg-gray-800 text-gray-100 shadow z-50">
+      <div class="container mx-auto px-4 py-4 flex justify-center space-x-8">
+        <a href="{{ '/' | relative_url }}" class="px-3 py-2 rounded hover:bg-gray-700 hover:text-indigo-400 transition">Home</a>
+        <a href="{{ '/posts/' | relative_url }}" class="px-3 py-2 rounded hover:bg-gray-700 hover:text-indigo-400 transition">All Posts</a>
+      </div>
+    </nav>
+    <main class="container mx-auto px-4 pt-24 pb-8">
       {{ content }}
     </main>
   </body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,10 +2,9 @@
 layout: default
 ---
 <article>
-  <h1>{{ page.title }}</h1>
-  <p><small>{{ page.date | date: "%B %d, %Y" }}</small></p>
+  <h1 class="text-3xl font-bold mb-4">{{ page.title }}</h1>
   {% if page.image %}
-    <img src="{{ page.image | relative_url }}" alt="{{ page.title }}">
+    <img src="{{ page.image | relative_url }}" alt="{{ page.title }}" class="mb-4 rounded">
   {% endif %}
   {{ content }}
 </article>

--- a/index.html
+++ b/index.html
@@ -17,16 +17,15 @@ title: Home
         {% if post.image %}
           <img src="{{ post.image | relative_url }}" alt="{{ post.title }}" class="mb-4 rounded">
         {% endif %}
-        <h3 class="text-xl font-bold mb-2"><a href="{{ post.url | relative_url }}" class="text-blue-600 hover:underline">{{ post.title }}</a></h3>
-        <p class="text-sm text-gray-500 mb-2">{{ post.date | date: "%B %d, %Y" }}</p>
+        <h3 class="text-xl font-bold mb-2"><a href="{{ post.url | relative_url }}" class="text-indigo-400 hover:underline">{{ post.title }}</a></h3>
         {% if post.summary %}
           <p class="mb-4">{{ post.summary }}</p>
         {% endif %}
-        <a href="{{ post.url | relative_url }}" class="text-blue-600 hover:underline">Read more &rarr;</a>
+        <a href="{{ post.url | relative_url }}" class="text-indigo-400 hover:underline">Read more &rarr;</a>
       </article>
     {% endfor %}
   </div>
   <div class="mt-8">
-    <a href="{{ '/posts/' | relative_url }}" class="text-blue-500 hover:underline">View all posts &rarr;</a>
+    <a href="{{ '/posts/' | relative_url }}" class="text-indigo-400 hover:underline">View all posts &rarr;</a>
   </div>
 </section>

--- a/posts.html
+++ b/posts.html
@@ -13,13 +13,12 @@ permalink: /posts/
         <img src="{{ post.image | relative_url }}" alt="{{ post.title }}" class="mb-4 rounded">
       {% endif %}
       <h3 class="text-xl font-bold mb-2">
-        <a href="{{ post.url | relative_url }}" class="text-blue-600 hover:underline">{{ post.title }}</a>
+        <a href="{{ post.url | relative_url }}" class="text-indigo-400 hover:underline">{{ post.title }}</a>
       </h3>
-      <p class="text-sm text-gray-500 mb-2">{{ post.date | date: "%B %d, %Y" }}</p>
       {% if post.summary %}
         <p class="mb-4">{{ post.summary }}</p>
       {% endif %}
-      <a href="{{ post.url | relative_url }}" class="text-blue-600 hover:underline">Read more &rarr;</a>
+      <a href="{{ post.url | relative_url }}" class="text-indigo-400 hover:underline">Read more &rarr;</a>
     </article>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- Add fixed top navigation bar with Home and All Posts links
- Show only cover image, title, summary, and "Read more" for posts across the site
- Update home and posts pages with modern dark styling

## Testing
- ⚠️ `bundle exec jekyll build` *(missing jekyll executable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a2a3581c83338eb878d3c043db40